### PR TITLE
Added basic Dockerfile for local dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:8
+
+# install dash-core
+# https://github.com/dashpay/docker-dashd/blob/master/Dockerfile
+ADD https://github.com/dashpay/dash/releases/download/v0.12.1.4/dashcore-0.12.1.4-linux64.tar.gz /tmp/
+RUN tar -xvf /tmp/dashcore-*.tar.gz -C /tmp/
+RUN cp /tmp/dashcore*/bin/*  /usr/local/bin
+RUN rm -rf /tmp/dashcore*
+
+# create app directory
+WORKDIR /usr/src/app
+
+# copy package.json to app directory
+COPY package.json .
+# install dependencies before copying the full source
+# this makes use of layer caching to only reinstall when package.json changes
+# http://bitjudo.com/blog/2014/03/13/building-efficient-dockerfiles-node-dot-js/
+RUN npm install
+
+# copy app src
+COPY . .
+
+EXPOSE 3000
+CMD dashd -daemon && npm run dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3"
+services:
+  webserver:
+    build: .
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/usr/src/app

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Helium Budget Proposals website",
   "main": "index.js",
   "scripts": {
-    "dev": "nodemon index.js"
+    "dev": "nodemon -L index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds a Dockerfile for local development. There are a couple things I could use your feedback on:

- I'm currently starting dashd without any parameters [here](https://github.com/jschr/heliumpay-budgetweb-backend/blob/ae7dfc8dfab12f8fd84125de2861da655f6cf5fe/Dockerfile#L24). I'm still familiarizing myself with the command but I think ideally we would start this with the same parameters as production.

- The server does not wait for the dashd to download the wallet before serving the API. This results in 500 errors until the wallet is done downloading. Not sure how best to resolve this but if we plan to dockerize the production servers, add tests and use CI/CD we'll probably need to figure this out. Unfortunately I'm still pretty new to docker so not sure the best way to move forward with fixing it.

In order to make nodemon work with the docker container I had to put it in legacy watch mode. This seems to be the suggested workaround according to nodemon docs: https://github.com/remy/nodemon#application-isnt-restarting