### PR TITLE
Add errors middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const createRouter = require('express-promise-router')
 const app = express()
 const requireAll = require('require-all')
 const utilsV0 = require('./v0/utils')
+const middlewareV0 = require('./v0/middleware')
 
 app.use(function(req, res, next) {
 
@@ -55,6 +56,8 @@ app.get('/', async (req, res) => {
 	const data = {"All available endpoints": routesUrls.sort()}
 	res.json(data)
 })
+
+app.use(middlewareV0.errors())
 
 app.listen(3000, () => {
 	console.log('Listening on port 3000!')

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const express = require('express')
+const createRouter = require('express-promise-router')
 const app = express()
 const requireAll = require('require-all')
 const utilsV0 = require('./v0/utils')
@@ -28,7 +29,7 @@ const allRoutes = requireAll({
 // Import all routes
 let allRoutesStrings = []
 function importObject(obj, currentRoute) {
-	const router = express.Router()
+	const router = createRouter()
 	app.use(currentRoute, router)
 	for (const key in obj) {
 		if (!obj.hasOwnProperty(key))

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "child-process-promise": "^2.2.1",
     "express": "^4.15.4",
+    "express-promise-router": "^2.0.0",
     "moment": "^2.18.1",
     "nodemon": "^1.11.0",
     "require-all": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/KristerV/budget-proposals#readme",
   "dependencies": {
+    "child-process-promise": "^2.2.1",
     "express": "^4.15.4",
     "moment": "^2.18.1",
     "nodemon": "^1.11.0",

--- a/v0/core/core-utils.js
+++ b/v0/core/core-utils.js
@@ -1,5 +1,6 @@
 const { execFile } = require('child-process-promise')
 const conf = require('../config')
+const { InternalServerError } = require('../errors')
 
 module.exports.runCliCmd = async function(options) {
 	let data
@@ -12,11 +13,7 @@ module.exports.runCliCmd = async function(options) {
 		data = stdout
 		data.status = 200
 	} catch(e) {
-		data = {
-			status: 500,
-			command: e.cmd,
-			message: e.toString().replace(/\n/g, '; ')
-		}
+		throw new InternalServerError(e.toString().replace(/\n/g, '; '))
 	}
 
 	// Try return an object

--- a/v0/core/core-utils.js
+++ b/v0/core/core-utils.js
@@ -1,28 +1,22 @@
-const child_process = require('child_process')
+const { execFile } = require('child-process-promise')
 const conf = require('../config')
 
 module.exports.runCliCmd = async function(options) {
 	let data
-	
+
 	if (typeof options === 'string')
 		options = [options]
 
 	try {
-		data = await new Promise((resolve, reject) => {
-			child_process.execFile(conf["cli-command"], options, (err, result) => {
-				if (err)
-					reject(err)
-				else
-					resolve(result)
-			})
-		})
-		data.status = 200;
+		const { stdout } = await execFile(conf["cli-command"], options)
+		data = stdout
+		data.status = 200
 	} catch(e) {
 		data = {
 			status: 500,
 			command: e.cmd,
 			message: e.toString().replace(/\n/g, '; ')
-		};
+		}
 	}
 
 	// Try return an object

--- a/v0/core/proposals/routes.js
+++ b/v0/core/proposals/routes.js
@@ -10,6 +10,7 @@ module.exports = function(app) {
 		let proposalsList = Object.values(withStatuses)
 		if (req.query.status)
 			proposalsList = proposalsList.filter(proposal => req.query.status === proposal.status)
+
 		res.json(proposalsList)
 	})
 

--- a/v0/errors/createHttpError.js
+++ b/v0/errors/createHttpError.js
@@ -1,0 +1,15 @@
+module.exports = function (name, code) {
+  return class HttpError extends Error {
+    constructor(message) {
+      super(message)
+
+      // error details
+      this.name = name
+      this.message = message
+      this.code = code
+
+      // add stack trace to error object
+      Error.captureStackTrace(this, this.constructor)
+    }
+  }
+}

--- a/v0/errors/index.js
+++ b/v0/errors/index.js
@@ -1,0 +1,5 @@
+const createHttpError = require('./createHttpError')
+
+module.exports = {
+  InternalServerError: createHttpError('InternalServerError', 500)
+}

--- a/v0/middleware/errors.js
+++ b/v0/middleware/errors.js
@@ -1,0 +1,11 @@
+module.exports = function createErrorsMiddleware() {
+  return function errorsMiddleware(err, req, res, next) {
+    // TODO: when logging is added, obfuscate error messages with code >= 500
+    // and remove stack traces in production
+    res.status(err.code).json({
+      code: err.code,
+      message: err.message,
+      stack: err.stack
+    })
+  }
+}

--- a/v0/middleware/index.js
+++ b/v0/middleware/index.js
@@ -1,0 +1,1 @@
+module.exports.errors = require('./errors')


### PR DESCRIPTION
This PR adds errors middleware for capturing errors that occur inside all routes.

This is just the initial structure, going forward it should be trivial to add other common http errors (401s, 403s, 404s etc...)

To avoid wrapping all route handlers with try / catches I added`express-promise-router`, which captures unresolved promises and passes the error to the middleware.

I also added `child-process-promise` to clean up the dash-cli command execution. 

There is a TODO to complete when we add logging. Typically in production you don't want to pass stack traces to the client nor error messages with >500 code because they likely contain sensitive info about the code.