### PR TITLE
Handle unexpected errors

### DIFF
--- a/v0/middleware/errors.js
+++ b/v0/middleware/errors.js
@@ -1,5 +1,13 @@
+const { InternalServerError } = require('../errors')
+
 module.exports = function createErrorsMiddleware() {
 	return function errorsMiddleware(err, req, res, next) {
+		// unexpected error
+		if (!err.code) {
+			console.error(err)
+			err = new InternalServerError(err.message)
+		}
+
 		// TODO: when logging is added, obfuscate error messages with code >= 500
 		// and remove stack traces in production
 		res.status(err.code).json({


### PR DESCRIPTION
Convert unexpected errors to an `InternalServerError`. 

This fixes an `invalid status code: 'undefined'` error from express (which also swallowed the original error message).