### PR TITLE
Simpler email links

### DIFF
--- a/mailer/index.js
+++ b/mailer/index.js
@@ -2,22 +2,22 @@
 // return type of getClient need to be mocked in setupTests.js
 const getClient = require('./getClient')
 
-module.exports.sendEmailConfirmation = async (to, userId, token) => {
+module.exports.sendEmailConfirmation = async (to, token) => {
 	const client = getClient()
 	return client.send({
 		to,
 		from: process.env.SUPPORT_EMAIL,
 		subject: 'Email Confirmation',
-		text: `${process.env.FRONTEND_URL}/users/${userId}/confirmEmail?token=${token}`
+		text: `${process.env.FRONTEND_URL}/confirmEmail?token=${token}`
 	})
 }
 
-module.exports.sendPasswordReset = async (to, userId, token) => {
+module.exports.sendPasswordReset = async (to, token) => {
 	const client = getClient()
 	return client.send({
 		to,
 		from: process.env.SUPPORT_EMAIL,
 		subject: 'Reset Password',
-		text: `${process.env.FRONTEND_URL}/users/${userId}/resetPassword?token=${token}`
+		text: `${process.env.FRONTEND_URL}/changePassword?token=${token}`
 	})
 }

--- a/v0/routes/login/sendPasswordResetEmail.js
+++ b/v0/routes/login/sendPasswordResetEmail.js
@@ -15,7 +15,7 @@ module.exports = async (req, res) => {
 		{ scopes: scopes.userResetPassword },
 		{ subject: encodeId(user.id), expiresIn: '5m' }
 	)
-	// TODO: api domain env var
+
 	await mailer.sendPasswordReset(user.email, token)
 
 	res.json(true)

--- a/v0/routes/login/sendPasswordResetEmail.js
+++ b/v0/routes/login/sendPasswordResetEmail.js
@@ -16,7 +16,7 @@ module.exports = async (req, res) => {
 		{ subject: encodeId(user.id), expiresIn: '5m' }
 	)
 	// TODO: api domain env var
-	await mailer.sendPasswordReset(user.email, encodeId(user.id), token)
+	await mailer.sendPasswordReset(user.email, token)
 
 	res.json(true)
 }

--- a/v0/routes/users/createUser.js
+++ b/v0/routes/users/createUser.js
@@ -22,7 +22,7 @@ module.exports = async (req, res) => {
 			{ scopes: scopes.userConfirmEmail },
 			{ subject: encodeId(user.id), expiresIn: '5m' }
 		)
-		// TODO: api domain env var
+
 		await mailer.sendEmailConfirmation(user.email, token)
 	}
 

--- a/v0/routes/users/createUser.js
+++ b/v0/routes/users/createUser.js
@@ -23,7 +23,7 @@ module.exports = async (req, res) => {
 			{ subject: encodeId(user.id), expiresIn: '5m' }
 		)
 		// TODO: api domain env var
-		await mailer.sendEmailConfirmation(user.email, encodeId(user.id), token)
+		await mailer.sendEmailConfirmation(user.email, token)
 	}
 
 	res.json(User.toJSON(user))

--- a/v0/routes/users/updateUser.js
+++ b/v0/routes/users/updateUser.js
@@ -25,7 +25,7 @@ module.exports = async (req, res) => {
 			{ scopes: scopes.userConfirmEmail },
 			{ subject: encodeId(user.id), expiresIn: '5m' }
 		)
-		await mailer.sendEmailConfirmation(user.email, encodeId(user.id), token)
+		await mailer.sendEmailConfirmation(user.email, token)
 	}
 
 	const updatedUser = await User.update(user.id, {

--- a/v0/routes/users/updateUser.js
+++ b/v0/routes/users/updateUser.js
@@ -25,6 +25,7 @@ module.exports = async (req, res) => {
 			{ scopes: scopes.userConfirmEmail },
 			{ subject: encodeId(user.id), expiresIn: '5m' }
 		)
+
 		await mailer.sendEmailConfirmation(user.email, token)
 	}
 


### PR DESCRIPTION
Simplified the frontend endpoints that handle confirm email and password reset. Passing in user id isn't necessary.