### PR TITLE
Increase bytes allowed on stdout (max buffer error)

### DIFF
--- a/v0/routes/core/core-utils.js
+++ b/v0/routes/core/core-utils.js
@@ -2,13 +2,15 @@ const { execFile } = require('child-process-promise')
 const conf = require('../../config')
 const { InternalServerError } = require('../../errors')
 
-module.exports.runCliCmd = async function(options) {
+const maxBuffer = 1024 * 500 // 512kb
+
+module.exports.runCliCmd = async function(args) {
 	let data
 
-	if (typeof options === 'string') options = [options]
+	if (typeof args === 'string') args = [args]
 
 	try {
-		const { stdout } = await execFile(conf['cli-command'], options)
+		const { stdout } = await execFile(conf['cli-command'], args, { maxBuffer })
 		data = stdout
 		data.status = 200
 	} catch (e) {


### PR DESCRIPTION
My localhost was crashing with max buffer errors when hitting proposals with the dash-cli. This was the fix. Not sure if we'd run into this anytime soon with heliumd but this PR can at least serve as documentation (feel free to close).

The default is 200kb and the response seems to return about ~240kb. 