### PR TITLE
use singular table names

### DIFF
--- a/database/config.js
+++ b/database/config.js
@@ -9,7 +9,7 @@ module.exports = {
 		ssl: !!process.env.DB_SSL
 	},
 	migrations: {
-		tableName: 'migrations',
+		tableName: 'migration',
 		directory: './database/migrations'
 	}
 }

--- a/database/migrations/20170901190835_user.js
+++ b/database/migrations/20170901190835_user.js
@@ -2,7 +2,7 @@ const getDbDriver = require('../getDbDriver')
 
 module.exports.up = async () => {
 	const db = await getDbDriver()
-	return db.schema.createTable('users', t => {
+	return db.schema.createTable('user', t => {
 		t.increments('id')
 		t.timestamp('createdAt').notNullable()
 		t.timestamp('updatedAt').notNullable()
@@ -18,5 +18,5 @@ module.exports.up = async () => {
 
 module.exports.down = async () => {
 	const db = await getDbDriver()
-	return db.schema.dropTable('users')
+	return db.schema.dropTable('user')
 }

--- a/database/models/user.js
+++ b/database/models/user.js
@@ -8,7 +8,7 @@ const { createTimestamps, updateTimestamps, withTransaction } = require('./utils
  * @module User
  */
 
-const table = 'users'
+const table = 'user'
 const privateFields = ['password']
 
 /**
@@ -92,7 +92,7 @@ module.exports.findOne = async attrs => {
 	const db = await getDbDriver()
 	const user = await db
 		.first()
-		.from('users')
+		.from(table)
 		.where(attrs)
 
 	return user
@@ -107,7 +107,7 @@ module.exports.findAll = async attrs => {
 	const db = await getDbDriver()
 	const user = await db
 		.select()
-		.from('users')
+		.from(table)
 		.where(attrs)
 
 	return user


### PR DESCRIPTION
seems to be more inline with popular conventions.

will drop production db tables so next deploy runs the migrations from scratch.